### PR TITLE
修复 iphone 手机点击聊天框放大的问题

### DIFF
--- a/app/components/chat/index.tsx
+++ b/app/components/chat/index.tsx
@@ -172,7 +172,7 @@ const Chat: FC<IChatProps> = ({
               }
               <Textarea
                 className={`
-                  block w-full px-2 pr-[118px] py-[7px] leading-5 max-h-none text-sm text-gray-700 outline-none appearance-none resize-none
+                  block w-full px-2 pr-[118px] py-[7px] leading-5 max-h-none text-base text-gray-700 outline-none appearance-none resize-none
                   ${visionConfig?.enabled && 'pl-12'}
                 `}
                 value={query}


### PR DESCRIPTION
iphone 字体小于 16px，点击输入框会变大撑开页面