### PR TITLE
fix: can not create conversation and send message when i have a file input variables

### DIFF
--- a/app/components/index.tsx
+++ b/app/components/index.tsx
@@ -343,7 +343,7 @@ const Main: FC<IMainProps> = () => {
       type: 'image',
       transfer_method: fileItem.transferMethod,
       url: fileItem.url,
-      upload_file_id: fileItem.id,
+      upload_file_id: fileItem.uploadedId,
     }
   }
 


### PR DESCRIPTION
If my application defines a file-type input parameter, after I successfully upload a file, when creating a new session, I do not pass in the file ID obtained from the upload I just did. This causes the message sending to fail after the session is created, and an error is reported because the file cannot be found.

