### PR TITLE
Add think block support for AI assistant messages

### DIFF
--- a/app/components/base/streamdown-markdown.tsx
+++ b/app/components/base/streamdown-markdown.tsx
@@ -1,16 +1,173 @@
 'use client'
+import React, { useState, useEffect, useMemo } from 'react'
 import { Streamdown } from 'streamdown'
+import type { ThinkBlockStatus } from '@/app/components/chat/think-block'
+import { ThinkBlockHeader, ThinkBlockContent } from '@/app/components/chat/think-block'
 import 'katex/dist/katex.min.css'
 
 interface StreamdownMarkdownProps {
   content: string
   className?: string
+  isStreaming?: boolean
 }
 
-export function StreamdownMarkdown({ content, className = '' }: StreamdownMarkdownProps) {
+const extractThinkContent = (
+  rawContent: string,
+): {
+  hasThinkBlock: boolean
+  thinkContent: string
+  mainContent: string
+  thinkClosed: boolean
+} => {
+  // Support both <think> and <details> tags
+  const thinkStartTag = '<think>'
+  const thinkEndTag = '</think>'
+
+  // Check for <think> tag
+  const thinkStartIndex = rawContent.indexOf(thinkStartTag)
+  if (thinkStartIndex !== -1) {
+    // Allow up to 10 characters before <think>
+    const contentBeforeThink = rawContent.substring(0, thinkStartIndex).trim()
+    const isThinkAtEffectiveStart
+      = thinkStartIndex === 0
+        || contentBeforeThink.length === 0
+        || contentBeforeThink.length <= 10
+
+    if (isThinkAtEffectiveStart) {
+      const thinkContentStart = thinkStartIndex + thinkStartTag.length
+      const endTagIndex = rawContent.indexOf(thinkEndTag, thinkContentStart)
+
+      if (endTagIndex !== -1) {
+        const thinkContent = rawContent.substring(thinkContentStart, endTagIndex)
+        const mainContent = rawContent.substring(endTagIndex + thinkEndTag.length)
+        return {
+          hasThinkBlock: true,
+          thinkContent,
+          mainContent,
+          thinkClosed: true,
+        }
+      }
+
+      // Unclosed <think> tag
+      const thinkContent = rawContent.substring(thinkContentStart)
+      return {
+        hasThinkBlock: true,
+        thinkContent,
+        mainContent: '',
+        thinkClosed: false,
+      }
+    }
+  }
+
+  // Check for <details> tag
+  const detailsStartRegex = /<details(?:\s[^>]*)?>/i
+  const detailsMatch = rawContent.match(detailsStartRegex)
+
+  if (detailsMatch) {
+    const detailsStartIndex = rawContent.indexOf(detailsMatch[0])
+    const contentBeforeDetails = rawContent.substring(0, detailsStartIndex).trim()
+    const isDetailsAtEffectiveStart
+      = detailsStartIndex === 0
+        || contentBeforeDetails.length === 0
+        || contentBeforeDetails.length <= 10
+
+    if (isDetailsAtEffectiveStart) {
+      const detailsStartTag = detailsMatch[0]
+      const detailsEndTag = '</details>'
+      const detailsContentStart = detailsStartIndex + detailsStartTag.length
+      const endTagIndex = rawContent.indexOf(detailsEndTag, detailsContentStart)
+
+      if (endTagIndex !== -1) {
+        // Extract content inside <details>, remove <summary> if present
+        let detailsContent = rawContent.substring(detailsContentStart, endTagIndex)
+        const summaryRegex = /<summary[^>]*>[\s\S]*?<\/summary>/i
+        detailsContent = detailsContent.replace(summaryRegex, '').trim()
+
+        const mainContent = rawContent.substring(endTagIndex + detailsEndTag.length)
+        return {
+          hasThinkBlock: true,
+          thinkContent: detailsContent,
+          mainContent,
+          thinkClosed: true,
+        }
+      }
+
+      // Unclosed <details> tag
+      let detailsContent = rawContent.substring(detailsContentStart)
+      const summaryRegex = /<summary[^>]*>[\s\S]*?<\/summary>/i
+      detailsContent = detailsContent.replace(summaryRegex, '').trim()
+
+      return {
+        hasThinkBlock: true,
+        thinkContent: detailsContent,
+        mainContent: '',
+        thinkClosed: false,
+      }
+    }
+  }
+
+  // No think block found
+  return {
+    hasThinkBlock: false,
+    thinkContent: '',
+    mainContent: rawContent,
+    thinkClosed: false,
+  }
+}
+
+export function StreamdownMarkdown({
+  content,
+  className = '',
+  isStreaming = false,
+}: StreamdownMarkdownProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const { hasThinkBlock, thinkContent, mainContent, thinkClosed } = useMemo(
+    () => extractThinkContent(content),
+    [content],
+  )
+
+  // Determine think block status
+  const thinkStatus: ThinkBlockStatus = useMemo(() => {
+    if (!hasThinkBlock) { return 'completed' }
+    if (isStreaming && !thinkClosed) { return 'thinking' }
+    return 'completed'
+  }, [hasThinkBlock, isStreaming, thinkClosed])
+
+  // Auto-expand think block when it starts streaming
+  useEffect(() => {
+    if (hasThinkBlock && thinkStatus === 'thinking' && !isOpen) {
+      setIsOpen(true)
+    }
+  }, [hasThinkBlock, thinkStatus, isOpen])
+
+  const toggleOpen = () => setIsOpen(!isOpen)
+
   return (
     <div className={`streamdown-markdown ${className}`}>
-      <Streamdown>{content}</Streamdown>
+      {hasThinkBlock && (
+        <>
+          <ThinkBlockHeader
+            status={thinkStatus}
+            isOpen={isOpen}
+            onToggle={toggleOpen}
+          />
+          <ThinkBlockContent
+            markdownContent={thinkContent}
+            isOpen={isOpen}
+          />
+        </>
+      )}
+
+      {mainContent && (
+        <div className="main-content">
+          <Streamdown>{mainContent}</Streamdown>
+        </div>
+      )}
+
+      {!hasThinkBlock && !mainContent && (
+        <Streamdown>{content}</Streamdown>
+      )}
     </div>
   )
 }

--- a/app/components/base/streamdown-markdown.tsx
+++ b/app/components/base/streamdown-markdown.tsx
@@ -11,6 +11,9 @@ interface StreamdownMarkdownProps {
   isStreaming?: boolean
 }
 
+// Maximum characters allowed before think/details block
+const MAX_CHARS_BEFORE_BLOCK = 10
+
 const extractThinkContent = (
   rawContent: string,
 ): {
@@ -26,12 +29,12 @@ const extractThinkContent = (
   // Check for <think> tag
   const thinkStartIndex = rawContent.indexOf(thinkStartTag)
   if (thinkStartIndex !== -1) {
-    // Allow up to 10 characters before <think>
+    // Allow limited characters before <think>
     const contentBeforeThink = rawContent.substring(0, thinkStartIndex).trim()
     const isThinkAtEffectiveStart
       = thinkStartIndex === 0
         || contentBeforeThink.length === 0
-        || contentBeforeThink.length <= 10
+        || contentBeforeThink.length <= MAX_CHARS_BEFORE_BLOCK
 
     if (isThinkAtEffectiveStart) {
       const thinkContentStart = thinkStartIndex + thinkStartTag.length
@@ -69,7 +72,7 @@ const extractThinkContent = (
     const isDetailsAtEffectiveStart
       = detailsStartIndex === 0
         || contentBeforeDetails.length === 0
-        || contentBeforeDetails.length <= 10
+        || contentBeforeDetails.length <= MAX_CHARS_BEFORE_BLOCK
 
     if (isDetailsAtEffectiveStart) {
       const detailsStartTag = detailsMatch[0]

--- a/app/components/chat/answer/index.tsx
+++ b/app/components/chat/answer/index.tsx
@@ -156,7 +156,7 @@ const Answer: FC<IAnswerProps> = ({
       {agent_thoughts?.map((item, index) => (
         <div key={index}>
           {item.thought && (
-            <StreamdownMarkdown content={item.thought} />
+            <StreamdownMarkdown content={item.thought} isStreaming={isResponding && !item.observation} />
           )}
           {/* {item.tool} */}
           {/* perhaps not use tool */}
@@ -202,7 +202,7 @@ const Answer: FC<IAnswerProps> = ({
                 : (isAgentMode
                   ? agentModeAnswer
                   : (
-                    <StreamdownMarkdown content={content} />
+                    <StreamdownMarkdown content={content} isStreaming={isResponding} />
                   ))}
               {suggestedQuestions.length > 0 && (
                 <div className="mt-3">

--- a/app/components/chat/think-block/index.tsx
+++ b/app/components/chat/think-block/index.tsx
@@ -1,0 +1,3 @@
+export { ThinkBlockHeader } from './think-block-header'
+export type { ThinkBlockStatus } from './think-block-header'
+export { ThinkBlockContent } from './think-block-content'

--- a/app/components/chat/think-block/think-block-content.tsx
+++ b/app/components/chat/think-block/think-block-content.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import React from 'react'
+import { Streamdown } from 'streamdown'
+
+interface ThinkBlockContentProps {
+  markdownContent: string
+  isOpen: boolean
+}
+
+export const ThinkBlockContent: React.FC<ThinkBlockContentProps> = ({
+  markdownContent,
+  isOpen,
+}) => {
+  return (
+    <div
+      id="think-block-content"
+      className={`
+        think-block-content overflow-hidden transition-all duration-300 ease-in-out
+        ${isOpen
+      ? 'max-h-[2000px] opacity-100 transform scale-100'
+      : 'max-h-0 opacity-0 transform scale-95'
+    }
+      `}
+    >
+      <div className="rounded-md border bg-gray-50 border-gray-200 p-4 mb-2 text-sm text-gray-700">
+        <Streamdown className="think-content">{markdownContent}</Streamdown>
+      </div>
+    </div>
+  )
+}

--- a/app/components/chat/think-block/think-block-header.tsx
+++ b/app/components/chat/think-block/think-block-header.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import React from 'react'
+import { ChevronRightIcon } from '@heroicons/react/24/outline'
+import { useTranslation } from 'react-i18next'
+
+export type ThinkBlockStatus = 'thinking' | 'completed' | 'stopped'
+
+interface ThinkBlockHeaderProps {
+  status: ThinkBlockStatus
+  isOpen: boolean
+  onToggle: () => void
+}
+
+export const ThinkBlockHeader: React.FC<ThinkBlockHeaderProps> = ({
+  status,
+  isOpen,
+  onToggle,
+}) => {
+  const { t } = useTranslation()
+  const isThinking = status === 'thinking'
+
+  const getStatusText = () => {
+    switch (status) {
+      case 'thinking':
+        return t('common.operation.thinking') || 'Thinking...'
+      case 'stopped':
+        return t('common.operation.stopped') || 'Stopped'
+      case 'completed':
+      default:
+        return t('common.operation.completed') || 'Thought for'
+    }
+  }
+
+  const statusText = getStatusText()
+
+  return (
+    <button
+      className={`
+        flex items-center justify-between gap-2 w-fit
+        mb-1 cursor-pointer rounded-md border px-3 py-1.5 text-sm
+        transition-all duration-200 focus:outline-none
+        ${isThinking
+      ? 'bg-blue-50 border-blue-200 text-blue-700 hover:bg-blue-100'
+      : 'bg-gray-50 border-gray-200 text-gray-700 hover:bg-gray-100'
+    }
+      `}
+      onClick={onToggle}
+      aria-expanded={isOpen}
+      aria-controls="think-block-content"
+      aria-label={`${statusText} - ${isOpen ? 'Collapse' : 'Expand'} think block`}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <ChevronRightIcon
+          className={`h-4 w-4 flex-shrink-0 transition-transform duration-200 ${
+            isOpen ? 'rotate-90' : 'rotate-0'
+          }`}
+        />
+        <span className="min-w-0 flex-1 truncate font-medium">
+          {statusText}
+        </span>
+      </div>
+
+      <div className="h-4 w-4 flex-shrink-0">
+        {isThinking && (
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600" />
+        )}
+      </div>
+    </button>
+  )
+}

--- a/i18n/lang/common.en.ts
+++ b/i18n/lang/common.en.ts
@@ -19,7 +19,7 @@ const translation = {
     ok: 'OK',
     thinking: 'Thinking...',
     stopped: 'Stopped',
-    completed: 'Thought for',
+    completed: 'Thought completed',
   },
   imageUploader: {
     uploadFromComputer: 'Upload from Computer',

--- a/i18n/lang/common.en.ts
+++ b/i18n/lang/common.en.ts
@@ -17,6 +17,9 @@ const translation = {
     like: 'like',
     dislike: 'dislike',
     ok: 'OK',
+    thinking: 'Thinking...',
+    stopped: 'Stopped',
+    completed: 'Thought for',
   },
   imageUploader: {
     uploadFromComputer: 'Upload from Computer',

--- a/i18n/lang/common.es.ts
+++ b/i18n/lang/common.es.ts
@@ -17,6 +17,9 @@ const translation = {
     like: 'Me gusta',
     dislike: 'No me gusta',
     ok: 'OK',
+    thinking: 'Pensando...',
+    stopped: 'Detenido',
+    completed: 'Pensamiento completado',
   },
   imageUploader: {
     uploadFromComputer: 'Subir desde el ordenador',

--- a/i18n/lang/common.fr.ts
+++ b/i18n/lang/common.fr.ts
@@ -17,6 +17,9 @@ const translation = {
     like: 'like',
     dislike: 'dislike',
     ok: 'D\'accord',
+    thinking: 'Réflexion...',
+    stopped: 'Arrêté',
+    completed: 'Réflexion terminée',
   },
   imageUploader: {
     uploadFromComputer: 'Télécharger depuis l\'ordinateur',

--- a/i18n/lang/common.ja.ts
+++ b/i18n/lang/common.ja.ts
@@ -17,6 +17,9 @@ const translation = {
     like: 'いいね',
     dislike: 'よくないね',
     ok: 'OK',
+    thinking: '考え中...',
+    stopped: '停止しました',
+    completed: '思考完了',
   },
   imageUploader: {
     uploadFromComputer: 'コンピューターからアップロード',

--- a/i18n/lang/common.vi.ts
+++ b/i18n/lang/common.vi.ts
@@ -17,6 +17,9 @@ const translation = {
     like: 'thích',
     dislike: 'không thích',
     ok: 'OK',
+    thinking: 'Đang suy nghĩ...',
+    stopped: 'Đã dừng',
+    completed: 'Hoàn thành suy nghĩ',
   },
   imageUploader: {
     uploadFromComputer: 'Tải lên từ máy tính',

--- a/i18n/lang/common.zh.ts
+++ b/i18n/lang/common.zh.ts
@@ -17,6 +17,9 @@ const translation = {
     like: '赞同',
     dislike: '反对',
     ok: '好的',
+    thinking: '思考中...',
+    stopped: '已停止',
+    completed: '思考完成',
   },
   imageUploader: {
     uploadFromComputer: '从本地上传',


### PR DESCRIPTION
## Summary
- Added collapsible think block support for AI assistant messages
- Supports both `<think>` and `<details>` tags for compatibility
- Integrated seamlessly with existing StreamdownMarkdown component

## Implementation Details

### Components Created
- **ThinkBlockHeader**: Displays thinking status with animated loading indicator, supports expand/collapse functionality
- **ThinkBlockContent**: Renders think block content using Streamdown with smooth transitions

### Core Features
- Automatic detection of `<think>` and `<details>` tags at the beginning of messages
- Real-time streaming support with "thinking" status animation
- Auto-expands when thinking starts for better user experience
- Smooth animations for expand/collapse transitions
- Full internationalization support (en, zh, ja, fr, es, vi)

### Technical Approach
The implementation extends the existing `StreamdownMarkdown` component to:
1. Extract think block content from the message
2. Render think blocks separately with appropriate styling
3. Maintain streaming capabilities for both think and main content
4. Handle incomplete/unclosed tags during streaming

## Test Plan
- [x] Tested with `<think>` tags
- [x] Tested with `<details>` tags  
- [x] Verified streaming behavior
- [x] Tested expand/collapse functionality
- [x] Verified all language translations display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)