### PR TITLE
fix: update eslint-config-next to version 15.5.9 to resolve dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "classnames": "^2.5.1",
     "copy-to-clipboard": "^3.3.3",
     "dify-client": "^2.3.1",
-    "eslint-config-next": "~14.2.32",
+    "eslint-config-next": "~15.5.9",
     "eventsource-parser": "^1.0.0",
     "husky": "^9.1.7",
     "i18next": "^23.16.4",


### PR DESCRIPTION
when execute `npm install`, there is a dependency issue

```
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: webapp-conversation@0.1.0
npm ERR! Found: eslint@9.35.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"~9.35.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^7.23.0 || ^8.0.0" from eslint-config-next@14.2.35
npm ERR! node_modules/eslint-config-next
npm ERR!   eslint-config-next@"~14.2.32" from the root project
```

The conflict is clear: eslint-config-next@~14.2.32 only accepts eslint ^7.23.0 || ^8.0.0, but you have eslint ~9.35.0. Meanwhile your next is already ^15.5.9 — Next.js 15 ships with eslint-config-next@15.x which added ESLint 9 support.

Fix: Update eslint-config-next to match your Next.js major version