### PR TITLE
fix: block send while files are still uploading

### DIFF
--- a/app/components/base/file-uploader-in-attachment/utils.ts
+++ b/app/components/base/file-uploader-in-attachment/utils.ts
@@ -97,7 +97,7 @@ export const getSupportFileType = (fileName: string, fileMimetype: string, isCus
 }
 
 export const getProcessedFiles = (files: FileEntity[]) => {
-  return files.filter(file => file.progress !== -1).map(fileItem => ({
+  return files.filter(file => file.progress !== -1 && fileIsUploaded(file)).map(fileItem => ({
     type: fileItem.supportFileType,
     transfer_method: fileItem.transferMethod,
     url: fileItem.url || '',

--- a/app/components/chat/index.tsx
+++ b/app/components/chat/index.tsx
@@ -98,6 +98,12 @@ const Chat: FC<IChatProps> = ({
 
   const handleSend = () => {
     if (!valid() || (checkCanSend && !checkCanSend())) { return }
+    const hasPendingImageUploads = files.some(file => file.progress !== -1 && file.progress < 100)
+    const hasPendingAttachmentUploads = attachmentFiles.some(file => file.progress !== -1 && file.progress < 100)
+    if (hasPendingImageUploads || hasPendingAttachmentUploads) {
+      logError(t('app.errorMessage.waitForFileUpload'))
+      return
+    }
     const imageFiles: VisionFile[] = files.filter(file => file.progress !== -1).map(fileItem => ({
       type: 'image',
       transfer_method: fileItem.type,

--- a/i18n/lang/app.en.ts
+++ b/i18n/lang/app.en.ts
@@ -27,6 +27,8 @@ const translation = {
     valueOfVarRequired: 'Variables value can not be empty',
     waitForResponse:
       'Please wait for the response to the previous message to complete.',
+    waitForFileUpload:
+      'Please wait for all files to finish uploading before sending.',
   },
   variableTable: {
     optional: 'Optional',

--- a/i18n/lang/app.es.ts
+++ b/i18n/lang/app.es.ts
@@ -27,6 +27,8 @@ const translation = {
     valueOfVarRequired: 'El valor de las variables no puede estar vacío',
     waitForResponse:
       'Por favor espere a que la respuesta al mensaje anterior se complete.',
+    waitForFileUpload:
+      'Espere a que todos los archivos terminen de cargarse antes de enviar.',
   },
 }
 

--- a/i18n/lang/app.fr.ts
+++ b/i18n/lang/app.fr.ts
@@ -27,6 +27,8 @@ const translation = {
     valueOfVarRequired: 'La valeur des variables ne peut pas être vide',
     waitForResponse:
       'Veuillez attendre que la réponse au message précédent soit terminée.',
+    waitForFileUpload:
+      'Veuillez attendre la fin du téléversement de tous les fichiers avant l’envoi.',
   },
   variableTable: {
     optional: 'Facultatif',

--- a/i18n/lang/app.ja.ts
+++ b/i18n/lang/app.ja.ts
@@ -27,6 +27,8 @@ const translation = {
     valueOfVarRequired: '変数の値は空にできません',
     waitForResponse:
       '前のメッセージの応答が完了するまでお待ちください。',
+    waitForFileUpload:
+      'すべてのファイルのアップロードが完了してから送信してください。',
   },
   variableTable: {
     optional: '任意',

--- a/i18n/lang/app.vi.ts
+++ b/i18n/lang/app.vi.ts
@@ -27,6 +27,8 @@ const translation = {
     valueOfVarRequired: 'Giá trị của biến không thể để trống',
     waitForResponse:
       'Vui lòng đợi phản hồi từ tin nhắn trước khi gửi tin nhắn mới.',
+    waitForFileUpload:
+      'Vui lòng đợi tất cả tệp tải lên xong trước khi gửi.',
   },
   variableTable: {
     optional: 'Tùy chọn',

--- a/i18n/lang/app.zh.ts
+++ b/i18n/lang/app.zh.ts
@@ -22,6 +22,7 @@ const translation = {
   errorMessage: {
     valueOfVarRequired: '变量值必填',
     waitForResponse: '请等待上条信息响应完成',
+    waitForFileUpload: '请等待所有文件上传完成后再发送',
   },
   variableTable: {
     optional: '可选',


### PR DESCRIPTION
Fixes #206

## Summary
- block chat sends while image or attachment uploads are still in progress
- only serialize attachment files once the upload has actually completed
- add localized error copy so users understand why send is temporarily blocked

## Validation
- `corepack pnpm lint`
- `NEXT_PUBLIC_APP_ID=test NEXT_PUBLIC_APP_KEY=test NEXT_PUBLIC_API_URL=http://localhost corepack pnpm build`

## Notes
- `corepack pnpm lint` reports existing repository warnings outside the touched files, but exits successfully
- this keeps the fix narrow to the chat send path and avoids silently sending messages without the selected files