### PR TITLE
fix: prevent server-side crash during locale matching

### DIFF
--- a/i18n/server.ts
+++ b/i18n/server.ts
@@ -25,6 +25,14 @@ export const getLocaleOnServer = async (): Promise<Locale> => {
   }
 
   // match locale
-  const matchedLocale = match(languages, locales, i18n.defaultLocale) as Locale
-  return matchedLocale
+  try {
+    const matchedLocale = match(
+      languages,
+      locales,
+      i18n.defaultLocale,
+    ) as Locale
+    return matchedLocale
+  } catch (e) {
+    return i18n.defaultLocale
+  }
 }


### PR DESCRIPTION
Currently, getLocaleOnServer can throw a RangeError if the match function from @formatjs/intl-localematcher encounters invalid language tags or environmental issues. This results in a 500 Internal Server Error for the user.

This PR adds a try-catch block around the locale matching logic to ensure that if matching fails for any reason, the application safely falls back to the defaultLocale instead of crashing.