### PR TITLE
fix: fall back to default locale when locale matching fails

### DIFF
--- a/i18n/server.ts
+++ b/i18n/server.ts
@@ -25,6 +25,12 @@ export const getLocaleOnServer = async (): Promise<Locale> => {
   }
 
   // match locale
-  const matchedLocale = match(languages, locales, i18n.defaultLocale) as Locale
-  return matchedLocale
+  try {
+    // Negotiator returns ['*'] when Accept-Language is missing or '*',
+    // and the locale cookie may hold an invalid tag — both make match() throw
+    return match(languages.filter(language => language !== '*'), locales, i18n.defaultLocale) as Locale
+  }
+  catch {
+    return i18n.defaultLocale as Locale
+  }
 }


### PR DESCRIPTION
## Problem

`getLocaleOnServer()` in `i18n/server.ts` crashes the root layout with an unhandled exception, so **every page returns HTTP 500**, when:

- the request has **no `Accept-Language` header** (or `Accept-Language: *`) — `Negotiator#languages()` returns `['*']`, which is not a valid locale tag, or
- the `locale` **cookie holds an invalid locale tag** (e.g. left over from another app on the same host).

In both cases `match()` from `@formatjs/intl-localematcher` throws:

```
RangeError: Incorrect locale information provided
    at Intl.getCanonicalLocales (<anonymous>)
    at getLocaleOnServer (i18n\server.ts:28:30)
    at async LocaleLayout (app\layout.tsx:11:18)
```

This is easy to hit in practice with `curl`, health checks, uptime monitors, and crawlers, or with a stale/foreign `locale` cookie in the browser.

This is the same known pitfall as in the Next.js i18n docs example (see vercel/next.js#58556).

## Reproduce

```bash
npm run dev
curl -i http://localhost:3000/                        # 500
curl -i -H 'Cookie: locale=invalid_tag!' http://localhost:3000/   # 500
```

## Fix

- Filter the `'*'` wildcard out of the negotiated languages before calling `match()`.
- Wrap `match()` in try/catch and fall back to `i18n.defaultLocale`, so an unparsable cookie value can never take the whole app down.

## Verification

After the fix, all of the following return 200 and render with the default locale:

- request without `Accept-Language`
- request with `Accept-Language: *`
- request with an invalid `locale` cookie

Normal locale negotiation (e.g. `Accept-Language: ja`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)